### PR TITLE
Adjust representers and disable sentry except for production

### DIFF
--- a/app/concepts/movies/representers/list.rb
+++ b/app/concepts/movies/representers/list.rb
@@ -13,7 +13,8 @@ module Movies
             id: movie.id,
             title: movie.title,
             genre: movie.movie_genre,
-            poster_url: movie.poster_url
+            poster_url: movie.poster_url,
+            length: movie.length
           }
         end
       end

--- a/app/concepts/movies/representers/single.rb
+++ b/app/concepts/movies/representers/single.rb
@@ -10,7 +10,10 @@ module Movies
       def basic
         {
           id: movie.id,
-          title: movie.title
+          title: movie.title,
+          genre: movie.movie_genre,
+          poster_url: movie.poster_url,
+          length: movie.length
         }
       end
     end

--- a/app/concepts/reservations/representers/single.rb
+++ b/app/concepts/reservations/representers/single.rb
@@ -10,6 +10,7 @@ module Reservations
       def basic
         {
           id: reservation.id,
+          user_id: reservation.user_id,
           seance_id: reservation.seance_id,
           status: reservation.reservation_status
         }

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,6 @@
 Sentry.init do |config|
   config.dsn = 'https://39ba3df194d04d50bac838121459e870@o877093.ingest.sentry.io/5827390'
+  config.enabled_environments = %w[production]
   config.breadcrumbs_logger = %i[active_support_logger http_logger]
 
   # Set tracesSampleRate to 1.0 to capture 100%


### PR DESCRIPTION
Adds missing attributes to movie and reservation representers and disables sentry everywhere except production.